### PR TITLE
DEV-1200: Solr full-text search results export

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ in the Solr server every time the container is started.
 The query below will retrieve only the documents that mention the exact phase `justice blame` in the full text
 `docker compose exec full_text_searcher python ht_full_text_search/ht_full_text_searcher.py --env dev --query_string "justice blame" --operator None --query_config ocronly`
 
+To do the same exact phrase query but export all results using solr result streaming:
+`docker compose exec full_text_searcher python ht_full_text_search/export_all_results.py '"justice blame"'`
+
 ### Scripts for running batch of queries, saving the results in a csv file and comparing the results with the expected ones or with the results of another query or search engine
 
 `python3 ht_full_text_search/scripts/generate_query_results.py`

--- a/ht_full_text_search/export_all_results.py
+++ b/ht_full_text_search/export_all_results.py
@@ -1,0 +1,78 @@
+import requests
+import json
+import yaml
+
+SOLR_URL="http://localhost:8081/solr/core-1x/query"
+SOLR_SHARDS = [f"http://solr-sdr-search-{i}:8081/solr/core-{i}x" for i in range(1,12)]
+
+# This is a quick attempt to do a query to solr more or less as we issue it in
+# production and to then export all results using the cursorMark results
+# streaming functionality.
+
+# This assumes the 'production' config with all shards available.
+
+# Usage:
+#
+# poetry run python3 ht_full_text_search/export_all_results.py 'your query string'
+#
+# If you want to do a phrase query, be sure to surround it in double quotes, e.g.
+# poetry run python3 ht_full_text_search/export_all_results.py '"a phrase"'
+
+def default_solr_params():
+  return {
+     "rows": 500,
+     "sort": "id asc",
+     "fl": ",".join(["title","author","id"]),
+     "wt": "json",
+     "shards": ",".join(SOLR_SHARDS)
+  }
+
+def send_query(params):
+  headers = {
+     "Content-type": "application/json"
+  }
+
+  response = requests.post(
+      url=SOLR_URL, params=params, headers=headers
+  )
+
+  return json.loads(response.content)
+
+def output_results(results):
+  for result in results['response']['docs']:
+    print("\t".join([result['id'],", ".join(result.get('author',[]))," ,".join(result.get('title',[]))]))
+
+def run_cursor(query):
+  params = default_solr_params()
+  params["cursorMark"] = "*"
+  params["q"] = make_query(query)
+
+  while True:
+    results = send_query(params)# send_query
+    output_results(results)
+    if params["cursorMark"] != results["nextCursorMark"]:
+      params["cursorMark"] = results["nextCursorMark"]
+    else:
+      break
+
+def format_boosts(query_fields):
+  formatted_boosts = ["^".join(map(str, field)) for field in query_fields]
+  return " ".join(formatted_boosts)
+
+def make_query(query):
+  return f"{{!edismax {solr_query_params()}}} {query}"
+
+def solr_query_params(config_file="config_files/full_text_search/config_query.yaml", conf_query="ocr"):
+  with open(config_file, "r") as file:
+      data = yaml.safe_load(file)[conf_query]
+
+      params = {
+        "pf": format_boosts(data["pf"]),
+        "qf": format_boosts(data["qf"]),
+        "mm": data["mm"],
+        "tie": data["tie"],
+      }
+      return " ".join([f"{k}='{v}'" for k,v in params.items()])
+
+if __name__ == "__main__": 
+   run_cursor('"poetic justice"')


### PR DESCRIPTION
This is a quick attempt that doesn't use the existing classes but copies/reuses some functionality from them in part because it wasn't immediately obvious how to add the additional solr parameters for cursorMark. It doesn't depend on anything else here except the config, but putting it here for now for want of anywhere else..

This is based in part on what was here, in part on what parameters I observed in production were in use for doing queries to full text solr (looking at the solr logs), and in part on @billdueber's https://github.com/mlibrary/solr_cursorstream gem.

The goal is to be able to have something reusable for getting results in bulk for full-text search queries; ideally both us and HTRC (with direct access to production solr) should be able to use it. @liseli I would love some feedback or thoughts on how we could best do this -- in particular if you think we should we try to clean up this repository and add the functionality for cursorMark/results streaming here (and if so how we should go about that), or if it makes sense to just have this be something separate.