### PR TITLE
The workflow is multiplatform

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ The API is based on the [FastAPI](https://fastapi.tiangolo.com/) library.
     * the Solr URL will be http://macc-ht-solr-lss-1.umdl.umich.edu:8081/solr/core-1x/query
     * to run the application in your local environment with the parameter `--env prod`.We don't have an 
     acceptable alternative, nor is it necessary to set up access to the production server via a Docker file.
-  * To query production, you will have to run the application locally and open and ssh connection to squishee-1.
-  * **Note**: squishee-1 will be retired, when that happen the new one name will be macc-ht-solr-lss-1.
+  * To query production, you will have to run the application locally and open an ssh connection to macc-ht.
   * To locally run the application, you can also set up the environment variable `HT_ENVIRONMENT` (dev or prod) to define the desired environment.
 
 ### Installation
@@ -95,7 +94,11 @@ The API is based on the [FastAPI](https://fastapi.tiangolo.com/) library.
   
       * `poetry init` # It will set up your local environment and repository details
       * `poetry env use python` # To find the virtual environment directory, created by poetry
-      * `source ~/ht-full-text-search-TUsF9qpC-py3.11/bin/activate` # Activate the virtual environment
+      * `source ~/ht-full-text-search-TUsF9qpC-py3.11/bin/activate` # Activate the virtual environment in Mac
+      * `C:\Users\user_name\AppData\Local\pypoetry\Cache\virtualenvs\ht-full-text-search-d4ARlKJT-py3.12\Scripts\Activate.ps1` # Activate the virtual environment in Windows
+      * ** Note **: 
+              If you are using a Mac, poetry creates their files in the home directory, e.g. /Users/user_name/Library/Caches/pypoetry/.
+              If you are using Windows, poetry creates their files in the home directory, e.g. C:\Users\user_name\AppData\Local\pypoetry\
 
 ### Creating A Pull Request
 
@@ -333,6 +336,10 @@ You will see the following screen with the API endpoints:
 
 * You can also run the API to search the documents in the Solr server using the command below:
 ```docker compose exec full_text_searcher python main.py --env dev```
+
+According to the env use in the command line, the API will use the Solr URL in the configuration file `config_search.py`.
+If you use `--env htrc` the Solr URL will be `https://analytics.dev.htrc.indiana.edu/solr/core-1x/query`, however the
+data is extracted from HathiTrust full-text search production index.
 
 **Use case 5**: Create an Excel file with collection statistics using Solr facets. 
 

--- a/README.md
+++ b/README.md
@@ -324,7 +324,7 @@ You will see the following screen with the API endpoints:
 
 * Query endpoint: 
 
-`curl --location 'http://localhost:8000/query/?query=biennial%20report&env=dev' --form 'query="'\''\"biennial report\"'\''"'`
+`curl --location 'http://localhost:8000/query/?query=biennial%20report' --form 'query="'\''\"biennial report\"'\''"'`
 
 * Status endpoint: 
 
@@ -334,12 +334,32 @@ You will see the following screen with the API endpoints:
 
 ```docker compose exec full_text_searcher python ht_full_text_search/export_all_results.py --env dev --query '"good"'```
 
-* You can also run the API to search the documents in the Solr server using the command below:
-```docker compose exec full_text_searcher python main.py --env dev```
+* You can also run the API to search the documents in the Solr server (dev environment) using the command below in the terminal:
+```docker compose exec full_text_searcher python main.py --env dev```. The Solr URLs to access dev and prod 
+environments are in the file `config_search.py`.
 
-According to the env use in the command line, the API will use the Solr URL in the configuration file `config_search.py`.
-If you use `--env htrc` the Solr URL will be `https://analytics.dev.htrc.indiana.edu/solr/core-1x/query`, however the
-data is extracted from HathiTrust full-text search production index.
+If you want to run the API or the `export_all_results.py` script using HTRC access point, you will have to run 
+the application outside the docker because it will access to the full-text search production index:
+
+To access full-text search index using HTRC Solr access point:
+
+  * ask Samitha to add your IP in the HTRC proxy.
+  * contact Samitha or Lianet to get the right Solr URL to access the HTRC Solr server. You will have to pass the Solr 
+    URL as a parameter in the command line.
+  * run the application outside the docker and using the parameters below: 
+    * `--env prod` and `--solr_url https://htrc_solr_url/...` 
+    
+For example, use the command below to run the script `export_all_results.py`:
+
+```python ht_full_text_search/export_all_results.py --env prod --query '"poetic justice"' --solr_url https://htrc_solr_url/...``` 
+
+and the command below to run the API:
+
+```python main.py --env prod --solr_url https://htrc_solr_url/...```
+
+Once the API is up, we can use the command below to query the full-text search using the API:
+
+```curl --location 'http://localhost:8000/query/?query=poetic%20justice' --form 'query="'\''\"poetic justice\"'\''"'```
 
 **Use case 5**: Create an Excel file with collection statistics using Solr facets. 
 

--- a/config_search.py
+++ b/config_search.py
@@ -34,7 +34,7 @@ def default_solr_params(env: str = "prod"):
     :param env:
     :return:
     """
-    if env == "prod" or env == "htrc":
+    if env == "prod":
         add_shards(DEFAULT_SOLR_PARAMS)
     return DEFAULT_SOLR_PARAMS
 

--- a/config_search.py
+++ b/config_search.py
@@ -2,6 +2,9 @@ import inspect
 import os
 import sys
 
+current_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+sys.path.insert(0, current_dir)
+
 # Full-text search config parameters
 SOLR_URL = {
     "prod": "http://macc-ht-solr-lss-1.umdl.umich.edu:8081/solr/core-1x/query",
@@ -11,20 +14,16 @@ SOLR_URL = {
 FULL_TEXT_SEARCH_SHARDS_X = ','.join([f"http://solr-sdr-search-{i}:8081/solr/core-{i}x" for i in range(1, 12)])
 FULL_TEXT_SEARCH_SHARDS_Y = ','.join([f"http://solr-sdr-search-{i}:8081/solr/core-{i}y" for i in range(1, 12)])
 
-current_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
-sys.path.insert(0, current_dir)
 
-QUERY_PARAMETER_CONFIG_FILE = "/".join(
-    [current_dir, "config_files/full_text_search/config_query.yaml"]
-)
-FACET_FILTERS_CONFIG_FILE = "/".join(
-    [current_dir, "config_files/full_text_search/config_facet_filters.yaml"]
-)
+
+QUERY_PARAMETER_CONFIG_FILE = os.path.join(current_dir, "config_files", "full_text_search", "config_query.yaml")
+
+FACET_FILTERS_CONFIG_FILE = os.path.join(current_dir, "config_files", "full_text_search", "config_facet_filters.yaml")
 
 DEFAULT_SOLR_PARAMS = {
     "rows": 500,
     "sort": "id asc",
-    "fl": ",".join(["title", "author", "id"]),
+    "fl": ",".join(["title", "author", "id", "shard", "score"]),
     "wt": "json"
 }
 
@@ -35,7 +34,7 @@ def default_solr_params(env: str = "prod"):
     :param env:
     :return:
     """
-    if env == "prod":
+    if env == "prod" or env == "htrc":
         add_shards(DEFAULT_SOLR_PARAMS)
     return DEFAULT_SOLR_PARAMS
 

--- a/ht_full_text_search/export_all_results.py
+++ b/ht_full_text_search/export_all_results.py
@@ -1,13 +1,20 @@
 import json
+import inspect
 import os
+import sys
 from argparse import ArgumentParser
 
 import requests
 import yaml
 from requests.auth import HTTPBasicAuth
 
-from config_search import QUERY_PARAMETER_CONFIG_FILE, default_solr_params, SOLR_URL
+current_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+sys.path.insert(0, current_dir)
 
+config_file_path = os.path.join(os.path.abspath(os.path.join(os.getcwd())),
+                                           'config_files', 'full_text_search', 'config_query.yaml')
+
+from config_search import default_solr_params, SOLR_URL
 
 # This is a quick attempt to do a query to solr more or less as we issue it in
 # production and to then export all results using the cursorMark results
@@ -33,7 +40,7 @@ def process_results(item: dict) -> str:
     })
 
 
-def solr_query_params(config_file=QUERY_PARAMETER_CONFIG_FILE, conf_query="ocr"):
+def solr_query_params(config_file=config_file_path, conf_query="ocr"):
 
     """ Prepare the Solr query parameters
     :param config_file: str, path to the config file

--- a/ht_full_text_search/ht_full_text_searcher_test.py
+++ b/ht_full_text_search/ht_full_text_searcher_test.py
@@ -1,4 +1,5 @@
 import config_search
+import os
 
 from ht_full_text_search.ht_full_text_searcher import HTFullTextSearcher
 
@@ -8,8 +9,8 @@ class TestHTFullTextSearcher:
         searcher = HTFullTextSearcher(
             solr_url=config_search.SOLR_URL["dev"],
             ht_search_query=ht_full_text_query,
-            user="solr",
-            password="solrRocks"
+            user=os.getenv("SOLR_USER"),
+            password=os.getenv("SOLR_PASSWORD")
         )
         solr_results = searcher.solr_result_query_dict(
             query_string="majority of the votes",

--- a/init.sh
+++ b/init.sh
@@ -6,13 +6,6 @@ else
   echo "🌎 .env does not exist. Copying .env-example to .env"
   cp env.example .env
 
-  #if [[ DEV == "true" ]];
-  #  then
-  #     ENV="dev"
-  #  else
-  #     ENV="prod"
-  #fi
-
   YOUR_UID=`id -u`
   YOUR_GID=`id -g`
   echo "🙂 Setting your UID ($YOUR_UID) and GID ($YOUR_UID) in .env"

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ exporter_api = {}
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--env", default=os.environ.get("HT_ENVIRONMENT", "dev"))
+    parser.add_argument("--solr_url", help="Solr url", default=None)
 
     args = parser.parse_args()
 
@@ -26,7 +27,11 @@ def main():
         """
         print("Connecting with Solr server")
 
-        exporter_api['obj'] = SolrExporter(SOLR_URL[args.env], args.env, user=os.getenv("SOLR_USER"),
+        if args.solr_url:
+            exporter_api['obj'] = SolrExporter(args.solr_url, args.env, user=os.getenv("SOLR_USER"),
+                                               password=os.getenv("SOLR_PASSWORD"))
+        else:
+            exporter_api['obj'] = SolrExporter(SOLR_URL[args.env], args.env, user=os.getenv("SOLR_USER"),
                                            password=os.getenv("SOLR_PASSWORD"))
         yield
         # Add some logic here to close the connection


### PR DESCRIPTION
This PR introduces changes to:

- Building images in GitHub action and running pytest in GitHub
-  Fixing an issue reading files in Windows that Pooja (from HTRC should test this testing change on a Windows machine).
- Adding the URL to access full-text search Solr index using an HTRC proxy connection. 
    To use the HTRC URL, your IP address must be added to the proxy. Lianet's IP was added, and she tested the connection, which is working fine.
- Updating the README file
- Changing the Solr health checker to simplify the logic to index data automatically when Solr is starting up in Docker.

**How to test this PR:**
- Check the test are running in GitHub (https://github.com/hathitrust/ht_full_text_search/actions/runs/11602828210)
- In your local machine:

```
git checkout DEV-1382-add-actions
docker compose up -d
```
**Run the tests**

`docker compose exec full_text_searcher python -m pytest
`
**Run a Solr query**
```
docker compose exec full_text_searcher python ht_full_text_search/ht_full_text_searcher.py \
    --env dev \
    --query_string "justice blame" \
    --query_config ocronly ```
