### PR TITLE
applied some changes to reproduce full-text search queries on Catalog…

### DIFF
--- a/config_files/catalog_search/config_query.yaml
+++ b/config_files/catalog_search/config_query.yaml
@@ -1,0 +1,26 @@
+# This config file contains the parameters used for creating the Solr query in Catalog Search. It is for testing purposes only.
+
+all:
+  pf: # Fields used for boosting results
+    - [title_ab, 10000]
+    - [title_a, 8000]
+    - [author, 1600]
+    - [author2, 800]
+    - [author_top, 100]
+  qf: # Fields used to find the results
+    - [title, 10]
+    - [author, 80]
+    - [author2, 50]
+    - [author_top, 30]
+  mm: "100%"
+  tie: 0.5
+  parser: "edismax"
+  debug: "all"
+
+titleonly:
+  parser: "edismax"
+  debug: "all"
+  qf:
+    - [title, 500000]
+  mm: "100%"
+  tie: 0.9

--- a/config_search.py
+++ b/config_search.py
@@ -6,9 +6,13 @@ current_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentfra
 sys.path.insert(0, current_dir)
 
 # Full-text search config parameters
-SOLR_URL = {
-    "prod": "http://macc-ht-solr-lss-1.umdl.umich.edu:8081/solr/core-1x/query",
-    "dev": "http://solr-lss-dev:8983/solr/core-x/query"
+FULL_TEXT_SOLR_URL = {
+    "prod": "http://macc-ht-solr-lss-1.umdl.umich.edu:8081/solr/core-1x",
+    "dev": "http://solr-lss-dev:8983/solr/core-x"
+}
+
+CATALOG_SOLR_URL = {
+    "dev": "http://localhost:8983"
 }
 
 FULL_TEXT_SEARCH_SHARDS_X = ','.join([f"http://solr-sdr-search-{i}:8081/solr/core-{i}x" for i in range(1, 12)])
@@ -29,6 +33,8 @@ DEFAULT_SOLR_PARAMS = {
 
 
 def default_solr_params(env: str = "prod"):
+    # TODO: Add shards is only for prod environment and full-text search, then I have to change this function to
+    # ensure we have access to Catalog in prod environment.
     """
     Return the default solr parameters
     :param env:

--- a/ht_full_text_search/ht_full_text_searcher.py
+++ b/ht_full_text_search/ht_full_text_searcher.py
@@ -4,7 +4,7 @@ import sys
 import inspect
 from argparse import ArgumentParser
 
-from config_search import SOLR_URL
+from config_search import FULL_TEXT_SOLR_URL
 from ht_full_text_search.ht_full_text_query import HTFullTextQuery
 from ht_searcher.ht_searcher import HTSearcher
 from typing import Text, List, Dict
@@ -110,7 +110,7 @@ if __name__ == "__main__":
     if args.solr_url:
         solr_url = args.solr_url
     else:  # Use the default solr url, depending on the environment. If prod environment, use shards
-        solr_url = SOLR_URL[args.env]
+        solr_url = FULL_TEXT_SOLR_URL[args.env]
 
     solr_user = os.getenv("SOLR_USER")
     solr_password = os.getenv("SOLR_PASSWORD")

--- a/ht_full_text_search/ht_full_text_searcher_test.py
+++ b/ht_full_text_search/ht_full_text_searcher_test.py
@@ -7,7 +7,7 @@ from ht_full_text_search.ht_full_text_searcher import HTFullTextSearcher
 class TestHTFullTextSearcher:
     def test_search(self, ht_full_text_query):
         searcher = HTFullTextSearcher(
-            solr_url=config_search.SOLR_URL["dev"],
+            solr_url=config_search.FULL_TEXT_SOLR_URL["dev"],
             ht_search_query=ht_full_text_query,
             user=os.getenv("SOLR_USER"),
             password=os.getenv("SOLR_PASSWORD")

--- a/ht_searcher/ht_searcher.py
+++ b/ht_searcher/ht_searcher.py
@@ -58,7 +58,7 @@ class HTSearcher:
         # In chunked transfer, the data stream is divided into a series of non-overlapping "chunks".
 
         response = requests.post(
-            url=self.solr_url, params=params, headers=self.headers, stream=True, auth=self.auth
+            url=f"{self.solr_url}/query", params=params, headers=self.headers, stream=True, auth=self.auth
         )
 
 

--- a/ht_searcher/ht_searcher_test.py
+++ b/ht_searcher/ht_searcher_test.py
@@ -70,7 +70,7 @@ def ht_searcher_fixture():
     """
 
     return HTSearcher(
-        solr_url=config_search.SOLR_URL["dev"],
+        solr_url=config_search.FULL_TEXT_SOLR_URL["dev"],
         environment="dev",
         user = os.getenv("SOLR_USER"),
         password = os.getenv("SOLR_PASSWORD")

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 import argparse
+import sys
 import os
+import inspect
 
 from contextlib import asynccontextmanager
 from fastapi.responses import StreamingResponse
@@ -7,11 +9,15 @@ from fastapi.responses import StreamingResponse
 import uvicorn
 from fastapi import FastAPI
 
-from config_search import SOLR_URL
+from config_search import FULL_TEXT_SOLR_URL
 from ht_full_text_search.export_all_results import SolrExporter
 
 exporter_api = {}
 
+# Add the parent directory ~/ht_full_text_search into the PYTHONPATH.
+current = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+#parent = os.path.dirname(current)
+sys.path.insert(0, current)
 
 def main():
     parser = argparse.ArgumentParser()
@@ -31,8 +37,9 @@ def main():
             exporter_api['obj'] = SolrExporter(args.solr_url, args.env, user=os.getenv("SOLR_USER"),
                                                password=os.getenv("SOLR_PASSWORD"))
         else:
-            exporter_api['obj'] = SolrExporter(SOLR_URL[args.env], args.env, user=os.getenv("SOLR_USER"),
-                                           password=os.getenv("SOLR_PASSWORD"))
+            exporter_api['obj'] = SolrExporter(FULL_TEXT_SOLR_URL[args.env], args.env, user=os.getenv("SOLR_USER"),
+                                               password=os.getenv("SOLR_PASSWORD"))
+
         yield
         # Add some logic here to close the connection
     app = FastAPI(title="HT_FullTextSearchAPI", description="Search phrases in Solr full text index", lifespan=lifespan)
@@ -50,7 +57,17 @@ def main():
         :param query: phrase to search
         :return: JSON with the results
         """
-        return StreamingResponse(exporter_api['obj'].run_cursor(query), media_type="application/json")
+
+        # TODO: run_cursor, should receive the query_string and the query_type (ocr or all).
+        # When the API is started the config file is loaded in memory,
+        # so the query type can be used to select the kind of query to run and the params dict is updated with the query
+        # string.
+
+        query_config_file_path = os.path.join(os.path.abspath(os.path.join(current)),
+                                              'config_files', 'full_text_search', 'config_query.yaml')
+
+        return StreamingResponse(exporter_api['obj'].run_cursor(query, query_config_path=query_config_file_path,
+                                                                conf_query="ocr"), media_type="application/json")
 
     uvicorn.run(app, host="0.0.0.0", port=8000)
 

--- a/scripts/generate_query_results_in_batch.py
+++ b/scripts/generate_query_results_in_batch.py
@@ -5,7 +5,7 @@ from argparse import ArgumentParser
 
 import pandas as pd
 
-from config_search import SOLR_URL
+from config_search import FULL_TEXT_SOLR_URL
 from ht_full_text_search.ht_full_text_query import HTFullTextQuery
 from ht_full_text_search.ht_full_text_searcher import HTFullTextSearcher
 
@@ -86,7 +86,7 @@ if __name__ == "__main__":
     if args.solr_url:
         solr_url = args.solr_url
     else:  # Use the default solr url, depending on the environment. If prod environment, use shards
-        solr_url = SOLR_URL[args.env]
+        solr_url = FULL_TEXT_SOLR_URL[args.env]
 
     solr_user = os.getenv("SOLR_USER")
     solr_password = os.getenv("SOLR_PASSWORD")

--- a/scripts/get_collection_statistics.py
+++ b/scripts/get_collection_statistics.py
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 
 import pandas as pd
 
-from config_search import SOLR_URL
+from config_search import FULL_TEXT_SOLR_URL
 from ht_full_text_search.ht_full_text_query import HTFullTextQuery
 from ht_full_text_search.ht_full_text_searcher import HTFullTextSearcher
 
@@ -210,7 +210,7 @@ if __name__ == "__main__":
     if args.solr_url:
         solr_url = args.solr_url
     else:  # Use the default solr url, depending on the environment. If prod environment, use shards
-        solr_url = SOLR_URL[args.env]
+        solr_url = FULL_TEXT_SOLR_URL[args.env]
 
     # The current production server does not require user and password
 


### PR DESCRIPTION
This PR introduces a tidy change to enable queries in the Catalog using the same logic as in the full-text search index. I have created a config file to add the Catalog queries. 

How to test this PR:

```
git checkout DEV-1479-create_catalog-config-query
docker compose up -d
```

Run the test

`docker compose exec full_text_searcher python -m pytest `

Run queries using the monitoring script

`docker compose exec full_text_searcher python ht_solr_monitoring/solr_query_monitoring.py --solr_host http://solr-lss-dev:8983 --collection_name core-x --env dev --cluster_name fulltext`